### PR TITLE
3a Add 1.20-beta control, migrate CNI/ztunnel to 1.19

### DIFF
--- a/istio/cni.yaml
+++ b/istio/cni.yaml
@@ -18,7 +18,7 @@ spec:
       - CreateNamespace=true
   sources:
     - repoURL: 'https://istio-release.storage.googleapis.com/charts'
-      targetRevision: 1.18.3
+      targetRevision: 1.19.3
       helm:
         valuesObject:
           revision: rapid

--- a/istio/control-plane-appset.yaml
+++ b/istio/control-plane-appset.yaml
@@ -6,6 +6,8 @@ spec:
   generators:
   - list:
       elements:
+      - version: 1.20.0-beta.0
+        revision: 1-20-beta
       - version: 1.18.3
         revision: 1-18-3
       - version: 1.19.1

--- a/istio/tags.yaml
+++ b/istio/tags.yaml
@@ -30,4 +30,4 @@ spec:
               revision: "1-18-5"
             rapid:
               revision: "1-19-3"
-          ztshim: "1-18-5"
+          ztshim: "1-19-3"

--- a/istio/ztunnel.yaml
+++ b/istio/ztunnel.yaml
@@ -9,7 +9,7 @@ spec:
   project: default
   source:
     repoURL: 'https://istio-release.storage.googleapis.com/charts'
-    targetRevision: 1.18.3
+    targetRevision: 1.19.3
     chart: ztunnel
     helm:
       valuesObject:


### PR DESCRIPTION
3a Add 1.20-beta control, migrate CNI/ztunnel to 1.19